### PR TITLE
Update Install-LastestMYOBAccountRight.ps1

### DIFF
--- a/Install-LastestMYOBAccountRight.ps1
+++ b/Install-LastestMYOBAccountRight.ps1
@@ -14,8 +14,8 @@ $ErrorActionPreference = "Continue"
 Start-Transcript -path ($scriptdir + "\Install-MYOB-AR-Client.log")
 
 # Get the current version
-$InstalledApps = Get-ChildItem -Path "HKLM:\SOFTWARE\WOW6432Node\MYOB\AccountRight Client" | Get-ItemProperty |select PSChildName
-$current = ($installedApps | Measure-Object -Property PSChildName -Maximum).maximum
+$InstalledApps = Get-ChildItem -Path "HKLM:\SOFTWARE\WOW6432Node\MYOB\AccountRight Client" | Get-ItemProperty | Select-Object @{Name='Version'; Expression={[version]$_.PSChildName}}
+$current = ($InstalledApps | Measure-Object -Property Version -Maximum).Maximum.ToString()
 Write-host "Latest Installed Version: " $current
 
 # Split the current version into year and month


### PR DESCRIPTION
This modification explicitly casts the PSChildName property to [version] type, ensuring that the versions are treated as such. The ToString() method is then used to convert the maximum version back to a string for your output. This should correctly select 2023.10 as the maximum version.